### PR TITLE
Fix Account.from_address checksum verification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nanocurrency (0.2.0)
+    nanocurrency (0.2.1)
       blake2b
 
 GEM

--- a/lib/nano/account.rb
+++ b/lib/nano/account.rb
@@ -47,11 +47,10 @@ module Nano
       public_key_bytes = Nano::Base32.decode(input[prefix_length, 52])
       checksum = Nano::Base32.decode(input[(prefix_length + 52)..-1])
       public_key_bin = Nano::Utils.hex_to_bin public_key_bytes
-      computed_check = Blake2b.hex(
-        public_key_bin, Blake2b::Key.none, 5
-      ).reverse.upcase
+      computed_check_bytes = Blake2b.bytes(public_key_bin, Blake2b::Key.none, 5).reverse
+      computed_check = Nano::Utils.bytes_to_hex(computed_check_bytes)
 
-      return nil if computed_check == checksum
+      return nil if computed_check != checksum
 
       Account.new(:address => input, :public_key => public_key_bytes)
     end

--- a/spec/nano/account_spec.rb
+++ b/spec/nano/account_spec.rb
@@ -1,0 +1,51 @@
+# MIT License
+#
+# Copyright (c) 2019 Nanotify
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require "nanocurrency"
+
+RSpec.describe Nano::Account do
+  describe "#from_address" do
+    subject { account }
+    let(:account) { Nano::Account.from_address(address) }
+    let(:address) { "nano_1khw4jm4yk8jxkbdanw9ioyo5twuxa9mrz3cs1akisz3xnt77nc8rx9oicnk" }
+
+    it { should_not be_nil }
+
+    context "when address is empty" do
+      let(:address) { "" }
+
+      it { should be_nil }
+    end
+
+    context "when address is invalid" do
+      let(:address) { "garbagioaddress" }
+
+      it { should be_nil }
+    end
+
+    context "when address has invalid checksum" do
+      let(:address) {"nano_1khw4jm4yk8jxkbdanw9ioyo5twuxa9mrz3cs1akisz3xnt77nc8rx9oic88" }
+
+      it { should be_nil }
+    end
+  end
+end
+


### PR DESCRIPTION
## Purpose

This PR fixes an issue where `Nano::Account.from_address` would accept addresses with invalid checksums.

Because `Blake2b.hex` returns a hexadecimal string, reversing it would actually reverse the nibbles, not the bytes, and the final values would not match.

The current code, however, accepts valid addresses (as well as invalid ones) because the checking condition for the computed checksum is actually inverted, the method should `return nil` if the given and computed checksums don't match, not if they do.

I also added tests for this condition.

Since there isn't any rubocop configuration and I couldn't find a style guide anywhere, I wrote tests a little bit differently than they were before and couldn't validate any code consistency. I'm open to making changes, in case this is an issue.
 